### PR TITLE
style: gofumpt fix ci

### DIFF
--- a/.github/workflows/gofumpt.yml
+++ b/.github/workflows/gofumpt.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version: "1.18"
       - name: Install gofumpt
-        run: go install mvdan.cc/gofumpt@latest
+        run: go install mvdan.cc/gofumpt@v0.4.0
       - name: Check formatting with gofumpt
         run: |
           if [ -n "$(gofumpt -l .)" ]; then


### PR DESCRIPTION
Fix the CI issue which is caused by incompatible versions between go1.18 vs `gofumpt`